### PR TITLE
Update index.js: fix bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ export default function mixin(Component, mixins) {
                 case 'messages':
                 case 'components':
                 case 'filters':
-                    Component.prototype[key] = merge(mixin, proto || {})
+                    Component.prototype[key] = merge(merge({}, mixin), proto || {})
                     break
                 // case 'delimiters':
                 // case 'trimWhitespace':


### PR DESCRIPTION
对 computed 之类，都是对象引用，不是值
所以，需要每次定义自己的一个新对象，否则原有的 mixin 的对象都会被修改，而一直传递下去。